### PR TITLE
修复 arXiv 图像相对路径拼接

### DIFF
--- a/skills/daily-papers/enrich_papers.py
+++ b/skills/daily-papers/enrich_papers.py
@@ -143,7 +143,10 @@ def extract_figure_url(html: str, arxiv_id: str) -> str:
         if url.startswith("/"):
             url = "https://arxiv.org" + url
         elif not url.startswith("http"):
-            url = "https://arxiv.org/html/" + url
+            if re.match(r"\d{4}\.\d{4,5}v\d+/", url):
+                url = "https://arxiv.org/html/" + url
+            else:
+                url = f"https://arxiv.org/html/{arxiv_id}/" + url
         return url
     return ""
 


### PR DESCRIPTION
- 针对 arXiv HTML 中图像链接的两类相对路径分别处理。
- 若路径已包含 YYYY.NNNN[vN]/ 前缀，则拼接到 https://arxiv.org/html/。
- 否则补上 https://arxiv.org/html/{arxiv_id}/，避免生成错误链接。
