### PR TITLE
Fix Python 3.9 compat and enrich_papers.py SKILL.md invocation

### DIFF
--- a/skills/daily-papers-fetch/SKILL.md
+++ b/skills/daily-papers-fetch/SKILL.md
@@ -87,10 +87,10 @@ python3 ../daily-papers/fetch_and_score.py --days N > /tmp/daily_papers_top30.js
 **先把 Phase 2 的 Top 30 结果保存到临时文件**，然后运行：
 
 ```bash
-cat /tmp/daily_papers_top30.json | python3 ../daily-papers/enrich_papers.py /tmp/daily_papers_enriched.json
+python3 ../daily-papers/enrich_papers.py /tmp/daily_papers_top30.json /tmp/daily_papers_enriched.json
 ```
 
-注意：使用**文件路径参数**（而非 stdout 重定向），避免 sandbox 环境下 stdout/stderr 混淆。
+注意：使用**两个文件路径参数（输入 + 输出）**，避免 sandbox 环境下 stdout/stderr 混淆。脚本会把第一个 `.json` 参数当作输入路径、第二个当作输出路径；如果只传一个 `.json` 它会被当作输入路径，结果走 stdout。
 
 脚本自动完成以下工作（Semaphore(10) 限制并发，单篇超时 30 秒）：
 - 并行抓取 HTML 页面 + PDF 页面

--- a/skills/daily-papers/download_note_images.py
+++ b/skills/daily-papers/download_note_images.py
@@ -8,6 +8,7 @@ For each external image link ![...](https://...):
   - Reachable (HTTP 200 within 10s) → keep as-is
   - Unreachable → download to assets/ and replace with Obsidian wikilink
 """
+from __future__ import annotations
 
 import asyncio
 import json

--- a/skills/daily-papers/enrich_papers.py
+++ b/skills/daily-papers/enrich_papers.py
@@ -20,6 +20,7 @@ Architecture:
     - Pure regex HTML parsing (no WebFetch / no external deps)
     - Per-request timeout via curl --max-time (no Python-level per-paper timeout)
 """
+from __future__ import annotations
 
 import asyncio
 import json

--- a/skills/daily-papers/fetch_and_score.py
+++ b/skills/daily-papers/fetch_and_score.py
@@ -11,6 +11,7 @@ Usage:
 
 Stderr: progress logs.  Stdout: JSON array of top papers (30 * days).
 """
+from __future__ import annotations
 
 import argparse
 import json


### PR DESCRIPTION
## Two related fixes hit on a fresh Python 3.9 run

This PR fixes two issues I hit on the first end-to-end run of `daily-papers` on a stock macOS (`python3 = 3.9.1`).

### 1. Add `from __future__ import annotations` to three scripts

These three scripts use PEP 604 union syntax (`X | None`, `tuple[A, B] | None`) in type annotations evaluated at function-definition time:

| File | Line | Annotation |
|------|------|------------|
| `skills/daily-papers/fetch_and_score.py` | 116 | `-> tuple[str, dict] \| None` |
| `skills/daily-papers/enrich_papers.py` | 558 | `output_path: str \| None` |
| `skills/daily-papers/download_note_images.py` | 131 | `-> Path \| None` |

PEP 604 syntax requires Python 3.10+ at definition time. The README states **Python 3.8+** as the minimum supported version, so the existing code can't actually run on Python 3.8 or 3.9.

Without the fix, the very first invocation of `python3 fetch_and_score.py` on a 3.9 system fails with:

```
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'
```

Adding `from __future__ import annotations` to the top of each file makes annotations lazily-evaluated strings, so PEP 604 syntax parses cleanly under 3.7+ — restoring the README's stated 3.8+ promise with no behavioral change.

### 2. Fix `daily-papers-fetch` SKILL.md Phase 3 invocation

The current SKILL.md (Phase 3) tells the model to run:

```bash
cat /tmp/daily_papers_top30.json | python3 ../daily-papers/enrich_papers.py /tmp/daily_papers_enriched.json
```

But `enrich_papers.py`'s argument parser (lines 501–508) treats the **first** `.json` positional argument as the **input** path, not output. So the command above gets parsed as:

- positional arg #1 ends in `.json` → `input_path = /tmp/daily_papers_enriched.json`
- stdin is also fed, but `input_path` is already set, so stdin is ignored

…and fails with:

```
Error: Input file not found: /tmp/daily_papers_enriched.json
```

(That file is supposed to be the *output*, so of course it doesn't exist yet.)

The fix uses the unambiguous two-argument form, which matches the script's own docstring example for Windows and is what the parser actually expects:

```bash
python3 ../daily-papers/enrich_papers.py /tmp/daily_papers_top30.json /tmp/daily_papers_enriched.json
```

I also added a one-sentence note documenting how the script's arg detection actually works (first `.json` = input, second `.json` = output, one-arg = input + stdout).

## Diff

```
 skills/daily-papers-fetch/SKILL.md          | 4 ++--
 skills/daily-papers/download_note_images.py | 1 +
 skills/daily-papers/enrich_papers.py        | 1 +
 skills/daily-papers/fetch_and_score.py      | 1 +
 4 files changed, 5 insertions(+), 2 deletions(-)
```

## Smoke test

After the fix, all three scripts import successfully under Python 3.9.1:

```
✓ fetch_and_score: imports OK
✓ enrich_papers: imports OK
✓ download_note_images: imports OK
```

And the corrected Phase 3 command produces a valid `/tmp/daily_papers_enriched.json` end-to-end.

## Notes

- These are surgical fixes; no logic changes.
- Tested end-to-end on macOS with the system `python3 = 3.9.1`.
- Happy to instead bump the README minimum to 3.10 if you'd rather not carry the `__future__` import — let me know your preference.
